### PR TITLE
Display name support for properties, events and services

### DIFF
--- a/widgetIDESupport/index.js
+++ b/widgetIDESupport/index.js
@@ -428,10 +428,26 @@ const TWWidgetFactory = function (widget) {
 if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
     (function () {
         let TWWidgetConstructor = TW.IDE.Widget;
+
+        const afterLoadCreate = function () {
+            // Apply all display names to properties/services/events. 
+            // This is done after the widget has loaded
+            const properties = this.allWidgetProperties().properties;
+            for (const property in properties) {
+                if(properties[property].displayName) {
+                    properties[property].name = properties[property].displayName;
+                }
+            }
+            this.updatedProperties({updateUi: true});
+            if (this.jqElement) {
+                this.updateProperties({updateUi: true});
+            }
+        };
+
         if (window.TWComposerWidget) {
             // Note that despite looking like a regular class, this will still require that widgets are created by thingworx
             // as they cannot function without the base instance created by `new TW.IDE.Widget()`
-            if ((!TWComposerWidget.prototype[versionSymbol]) || TWComposerWidget.prototype[versionSymbol] < 3) {
+            if ((!TWComposerWidget.prototype[versionSymbol]) || TWComposerWidget.prototype[versionSymbol] < 4) {
                 // Duplication needed for compatibility with previous versions
                 let prototype = {
                     widgetProperties() {
@@ -482,17 +498,8 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                         return result;
                     },
 
-                    afterLoad() {
-                        // Apply all display names to properties/services/events. 
-                        // This is done after the widget has loaded
-                        const properties = this.allWidgetProperties().properties;
-                        for (const property in properties) {
-                            if(properties[property].displayName) {
-                                properties[property].name = properties[property].displayName;
-                            }
-                        }
-                        this.updatedProperties();
-                    },
+                    afterLoad: afterLoadCreate,
+                    afterCreate: afterLoadCreate,
 
                     beforeSetProperty(key, value) {
                         if (this[willSetSymbol] && (key in this[willSetSymbol])) {
@@ -516,10 +523,11 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                 TWComposerWidget.prototype.widgetEvents = prototype.widgetEvents;
                 TWComposerWidget.prototype.widgetServices = prototype.widgetServices;
                 TWComposerWidget.prototype.afterLoad = prototype.afterLoad;
+                TWComposerWidget.prototype.afterCreate = prototype.afterCreate;
                 TWComposerWidget.prototype.beforeSetProperty = prototype.beforeSetProperty;
                 TWComposerWidget.prototype.afterSetProperty = prototype.afterSetProperty;
                 TWComposerWidget.prototype.afterAddBindingSource = prototype.afterAddBindingSource;
-                TWComposerWidget.prototype[versionSymbol] = 3;
+                TWComposerWidget.prototype[versionSymbol] = 4;
 
                 // Make the prototype read-only; future releases will be able to handle this
                 Object.defineProperty(window.TWComposerWidget, 'prototype', { writable: false });
@@ -654,17 +662,8 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                 return result;
             },
 
-            afterLoad() {
-                // Apply all display names to properties/services/events. 
-                // This is done after the widget has loaded
-                const properties = this.allWidgetProperties().properties;
-                for (const property in properties) {
-                    if (properties[property].displayName) {
-                        properties[property].name = properties[property].displayName;
-                    }
-                }
-                this.updatedProperties();
-            },
+            afterLoad: afterLoadCreate,
+            afterCreate: afterLoadCreate,
 
             beforeSetProperty(key, value) {
                 if (this[willSetSymbol] && (key in this[willSetSymbol])) {
@@ -684,7 +683,7 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                 }
             },
 
-            [versionSymbol]: 3
+            [versionSymbol]: 4
         });
 
         // Make the prototype read-only; future releases will be able to handle this

--- a/widgetIDESupport/index.js
+++ b/widgetIDESupport/index.js
@@ -83,6 +83,16 @@ export function defaultValue(value) {
 }
 
 /**
+ * Constructs and returns a property aspect that sets the display name of the property.
+ * This value will be displayed in composer instead of the declared property name
+ * @param {any} value               The display name that should be shown in the composer
+ * @return {TWPropertyAspect}       A property aspect.
+ */
+export function displayName(value) {
+    return TWPropertyAspect.aspectWithKeyAndValue('displayName', value);
+}
+
+/**
  * Constructs and returns a property aspect that sets the list of available options for a property.
  * @param {TWPropertySelectOptions[]} value An array of objects with text and value properties
  * @return {TWPropertyAspect}       A property aspect.
@@ -96,7 +106,7 @@ export function selectOptions(value) {
  * @param {TWPropertyMustImplement} value Set the options that the property must implement
  * @return {TWPropertyAspect}       A property aspect.
  */
- export function mustImplement(value) {
+export function mustImplement(value) {
     return TWPropertyAspect.aspectWithKeyAndValue('mustImplement', value);
 }
 
@@ -472,6 +482,18 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                         return result;
                     },
 
+                    afterLoad() {
+                        // Apply all display names to properties/services/events. 
+                        // This is done after the widget has loaded
+                        const properties = this.allWidgetProperties().properties;
+                        for (const property in properties) {
+                            if(properties[property].displayName) {
+                                properties[property].name = properties[property].displayName;
+                            }
+                        }
+                        this.updatedProperties();
+                    },
+
                     beforeSetProperty(key, value) {
                         if (this[willSetSymbol] && (key in this[willSetSymbol])) {
                             return this[this[willSetSymbol][key]](value);
@@ -493,6 +515,7 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                 TWComposerWidget.prototype.widgetProperties = prototype.widgetProperties;
                 TWComposerWidget.prototype.widgetEvents = prototype.widgetEvents;
                 TWComposerWidget.prototype.widgetServices = prototype.widgetServices;
+                TWComposerWidget.prototype.afterLoad = property.afterLoad;
                 TWComposerWidget.prototype.beforeSetProperty = prototype.beforeSetProperty;
                 TWComposerWidget.prototype.afterSetProperty = prototype.afterSetProperty;
                 TWComposerWidget.prototype.afterAddBindingSource = prototype.afterAddBindingSource;
@@ -503,7 +526,6 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
             }
             return;
         }
-        
 
         let internalStates = new WeakMap();
         window.TWComposerWidget = function (proto) {
@@ -630,6 +652,18 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                     }
                 }
                 return result;
+            },
+
+            afterLoad() {
+                // Apply all display names to properties/services/events. 
+                // This is done after the widget has loaded
+                const properties = this.allWidgetProperties().properties;
+                for (const property in properties) {
+                    if (properties[property].displayName) {
+                        properties[property].name = properties[property].displayName;
+                    }
+                }
+                this.updatedProperties();
             },
 
             beforeSetProperty(key, value) {

--- a/widgetIDESupport/index.js
+++ b/widgetIDESupport/index.js
@@ -515,7 +515,7 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                 TWComposerWidget.prototype.widgetProperties = prototype.widgetProperties;
                 TWComposerWidget.prototype.widgetEvents = prototype.widgetEvents;
                 TWComposerWidget.prototype.widgetServices = prototype.widgetServices;
-                TWComposerWidget.prototype.afterLoad = property.afterLoad;
+                TWComposerWidget.prototype.afterLoad = prototype.afterLoad;
                 TWComposerWidget.prototype.beforeSetProperty = prototype.beforeSetProperty;
                 TWComposerWidget.prototype.afterSetProperty = prototype.afterSetProperty;
                 TWComposerWidget.prototype.afterAddBindingSource = prototype.afterAddBindingSource;

--- a/widgetIDESupport/index.js
+++ b/widgetIDESupport/index.js
@@ -165,6 +165,11 @@ function getSymbol(symbolDesc) {
     return TW[symbolDesc];
 }
 
+/**
+ * The version of the TWComposerWidget prototype.
+ */
+const prototypeVersion = 4;
+
 const willSetSymbol = getSymbol('@@_willSet');
 const didSetSymbol = getSymbol('@@_didSet');
 const didBindSymbol = getSymbol('@@_didBind');
@@ -447,7 +452,7 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
         if (window.TWComposerWidget) {
             // Note that despite looking like a regular class, this will still require that widgets are created by thingworx
             // as they cannot function without the base instance created by `new TW.IDE.Widget()`
-            if ((!TWComposerWidget.prototype[versionSymbol]) || TWComposerWidget.prototype[versionSymbol] < 4) {
+            if ((!TWComposerWidget.prototype[versionSymbol]) || TWComposerWidget.prototype[versionSymbol] < prototypeVersion) {
                 // Duplication needed for compatibility with previous versions
                 let prototype = {
                     widgetProperties() {
@@ -527,7 +532,7 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                 TWComposerWidget.prototype.beforeSetProperty = prototype.beforeSetProperty;
                 TWComposerWidget.prototype.afterSetProperty = prototype.afterSetProperty;
                 TWComposerWidget.prototype.afterAddBindingSource = prototype.afterAddBindingSource;
-                TWComposerWidget.prototype[versionSymbol] = 4;
+                TWComposerWidget.prototype[versionSymbol] = prototypeVersion;
 
                 // Make the prototype read-only; future releases will be able to handle this
                 Object.defineProperty(window.TWComposerWidget, 'prototype', { writable: false });
@@ -683,7 +688,7 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                 }
             },
 
-            [versionSymbol]: 4
+            [versionSymbol]: prototypeVersion
         });
 
         // Make the prototype read-only; future releases will be able to handle this

--- a/widgetIDESupport/types/index.d.ts
+++ b/widgetIDESupport/types/index.d.ts
@@ -98,6 +98,14 @@ export function baseTypeRestriction(name): TWPropertyAspect;
 export function defaultValue(value): TWPropertyAspect;
 
 /**
+ * Constructs and returns a property aspect that sets the display name of the property.
+ * This value will be displayed in composer instead of the declared property name
+ * @param {any} value               The displayName value.
+ * @return {TWPropertyAspect}       A property aspect.
+ */
+export function displayName(value): TWPropertyAspect;
+
+/**
  * Constructs and returns a property aspect that sets the list of available options for a property.
  * @param {TWPropertySelectOptions[]} value An array of objects with text and value properties
  * @return {TWPropertyAspect}       A property aspect.


### PR DESCRIPTION
This change attempts to bring support for display names for widget properties, events and services.

The implementation works as following:
1. Set the widget property `displayName` (this gets returned by `this.widgetProperties()`)
2. In `this.afterLoad()`, change the property `name` attribute to the `displayName`.

However the above does not work, and the property remains with the old name. @BogdanMihaiciuc  if you have any idea why this is happening feel free to fix.