### PR TITLE
fix: Increase prototype version and also invoke in afterCreate

### DIFF
--- a/widgetIDESupport/index.js
+++ b/widgetIDESupport/index.js
@@ -428,10 +428,26 @@ const TWWidgetFactory = function (widget) {
 if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
     (function () {
         let TWWidgetConstructor = TW.IDE.Widget;
+
+        const afterLoadCreate = function () {
+            // Apply all display names to properties/services/events. 
+            // This is done after the widget has loaded
+            const properties = this.allWidgetProperties().properties;
+            for (const property in properties) {
+                if(properties[property].displayName) {
+                    properties[property].name = properties[property].displayName;
+                }
+            }
+            this.updatedProperties({updateUi: true});
+            if (this.jqElement) {
+                this.updateProperties({updateUi: true});
+            }
+        };
+
         if (window.TWComposerWidget) {
             // Note that despite looking like a regular class, this will still require that widgets are created by thingworx
             // as they cannot function without the base instance created by `new TW.IDE.Widget()`
-            if ((!TWComposerWidget.prototype[versionSymbol]) || TWComposerWidget.prototype[versionSymbol] < 3) {
+            if ((!TWComposerWidget.prototype[versionSymbol]) || TWComposerWidget.prototype[versionSymbol] < 4) {
                 // Duplication needed for compatibility with previous versions
                 let prototype = {
                     widgetProperties() {
@@ -482,17 +498,8 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                         return result;
                     },
 
-                    afterLoad() {
-                        // Apply all display names to properties/services/events. 
-                        // This is done after the widget has loaded
-                        const properties = this.allWidgetProperties().properties;
-                        for (const property in properties) {
-                            if(properties[property].displayName) {
-                                properties[property].name = properties[property].displayName;
-                            }
-                        }
-                        this.updatedProperties();
-                    },
+                    afterLoad: afterLoadCreate,
+                    afterCreate: afterLoadCreate,
 
                     beforeSetProperty(key, value) {
                         if (this[willSetSymbol] && (key in this[willSetSymbol])) {
@@ -516,10 +523,11 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                 TWComposerWidget.prototype.widgetEvents = prototype.widgetEvents;
                 TWComposerWidget.prototype.widgetServices = prototype.widgetServices;
                 TWComposerWidget.prototype.afterLoad = prototype.afterLoad;
+                TWComposerWidget.prototype.afterCreate = prototype.afterCreate;
                 TWComposerWidget.prototype.beforeSetProperty = prototype.beforeSetProperty;
                 TWComposerWidget.prototype.afterSetProperty = prototype.afterSetProperty;
                 TWComposerWidget.prototype.afterAddBindingSource = prototype.afterAddBindingSource;
-                TWComposerWidget.prototype[versionSymbol] = 3;
+                TWComposerWidget.prototype[versionSymbol] = 4;
 
                 // Make the prototype read-only; future releases will be able to handle this
                 Object.defineProperty(window.TWComposerWidget, 'prototype', { writable: false });
@@ -654,17 +662,8 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                 return result;
             },
 
-            afterLoad() {
-                // Apply all display names to properties/services/events. 
-                // This is done after the widget has loaded
-                const properties = this.allWidgetProperties().properties;
-                for (const property in properties) {
-                    if (properties[property].displayName) {
-                        properties[property].name = properties[property].displayName;
-                    }
-                }
-                this.updatedProperties();
-            },
+            afterLoad: afterLoadCreate,
+            afterCreate: afterLoadCreate,
 
             beforeSetProperty(key, value) {
                 if (this[willSetSymbol] && (key in this[willSetSymbol])) {
@@ -684,7 +683,7 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                 }
             },
 
-            [versionSymbol]: 3
+            [versionSymbol]: 4
         });
 
         // Make the prototype read-only; future releases will be able to handle this

--- a/widgetIDESupport/index.js
+++ b/widgetIDESupport/index.js
@@ -165,6 +165,11 @@ function getSymbol(symbolDesc) {
     return TW[symbolDesc];
 }
 
+/**
+ * The version of the TWComposerWidget prototype.
+ */
+const prototypeVersion = 4;
+
 const willSetSymbol = getSymbol('@@_willSet');
 const didSetSymbol = getSymbol('@@_didSet');
 const didBindSymbol = getSymbol('@@_didBind');
@@ -447,7 +452,7 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
         if (window.TWComposerWidget) {
             // Note that despite looking like a regular class, this will still require that widgets are created by thingworx
             // as they cannot function without the base instance created by `new TW.IDE.Widget()`
-            if ((!TWComposerWidget.prototype[versionSymbol]) || TWComposerWidget.prototype[versionSymbol] < 4) {
+            if ((!TWComposerWidget.prototype[versionSymbol]) || TWComposerWidget.prototype[versionSymbol] < prototypeVersion) {
                 // Duplication needed for compatibility with previous versions
                 let prototype = {
                     widgetProperties() {
@@ -527,7 +532,7 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                 TWComposerWidget.prototype.beforeSetProperty = prototype.beforeSetProperty;
                 TWComposerWidget.prototype.afterSetProperty = prototype.afterSetProperty;
                 TWComposerWidget.prototype.afterAddBindingSource = prototype.afterAddBindingSource;
-                TWComposerWidget.prototype[versionSymbol] = 4;
+                TWComposerWidget.prototype[versionSymbol] = prototypeVersion;
 
                 // Make the prototype read-only; future releases will be able to handle this
                 Object.defineProperty(window.TWComposerWidget, 'prototype', { writable: false });
@@ -683,7 +688,7 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                 }
             },
 
-            [versionSymbol]: 4
+            [versionSymbol]: prototypeVersion
         });
 
         // Make the prototype read-only; future releases will be able to handle this


### PR DESCRIPTION
I was able to get this working by:
 - increasing the prototype version to 4 to ensure that older widgets don't replace it
 - calling both updateProperties and updatedProperties (still not sure what each does differently)
 - setting the display name in both `afterCreate` and `afterLoad`
     - `afterCreate` is only invoked on newly created widgets
     - `afterLoad` is only invoked on widgets that already existed when opening a mashup 