### PR TITLE
Fix boolean and duplicated properties

### DIFF
--- a/widgetIDESupport/index.js
+++ b/widgetIDESupport/index.js
@@ -175,12 +175,24 @@ const didSetSymbol = getSymbol('@@_didSet');
 const didBindSymbol = getSymbol('@@_didBind');
 const versionSymbol = getSymbol('@@_version');
 
+
+/**
+ * Retrieves the store for decorated properties of the specified kind. If the specified
+ * prototype does not have a store of that type initialized, this function creates an
+ * empty store, then copies the decorator metadata from its super prototype and returns it.
+ * @param proto             The prototype for which the store should be retrieved.
+ * @param property          The symbol identifying the store kind to obtain.
+ * @returns                 The requested store.
+ */
 const _getInheritedProperty = function (proto, property) {
+    // If the store was already initialized, return it
     if (proto.hasOwnProperty(property)) return proto[property];
 
-    const superproto = Object.getPrototypeOf(proto);
-
+    // If no store was available, create an empty one
     proto[property] = {};
+
+    // And inherit all the superclass metadata
+    const superproto = Object.getPrototypeOf(proto);
     for (const key in superproto[property]) {
         proto[property][key] = superproto[property][key];
     }


### PR DESCRIPTION
This PR fixes the following:
 - Most property values were assigned as strings since the value was taken from `SinglePropertyValue` rather than `RawSinglePropertyValue`
 - Certain decorator aspects were copied on all classes that extended from a base class. This was because the check to initialise or retrieve the decorator store was always returning the superclass store rather than initialising a new one on the subclasses.