### PR TITLE
Some improvements

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,7 +51,7 @@ declare interface TWDataShape {
  * Note that on the client side, infotables are just dummy objects
  * and do not support any of the usual server-side methods.
  */
-declare interface TWInfotable {
+declare interface TWInfotable<T = any> {
     /**
      * The infotable's data shape.
      */
@@ -60,7 +60,7 @@ declare interface TWInfotable {
     /**
      * The contents of the infotable.
      */
-    rows: any[];
+    rows: T[];
 }
 
 /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -731,9 +731,16 @@ declare abstract class TWComposerWidget extends TWWidget {
     /**
      * Should be invoked whenever the widget's properties are updated.
      * Subclasses are expected to not override this method.
-     * @param updateUi      Defaults to false. Should be set to true to update the properties panel for this widget when it is selected.
+     * @param obj                  Parameters to pass into the function 
+     * @param obj.updateUi         Defaults to false. Should be set to true to update the properties panel for this widget when it is selected.
+     * @param obj.isWidthModified  Defaults to undefined. Should be set to false, if the width of the widget was not modified.
+     * @param obj.isHeightModified Defaults to undefined. Should be set to false, if the height of the widget was not modified.
      */
-    updateProperties({ updateUi }?: { updateUi?: boolean }): void;
+    updateProperties({ updateUi, isWidthModified, isHeightModified }?: {
+        updateUi?: boolean;
+        isWidthModified?: boolean;
+        isHeightModified?: boolean;
+    }): void;
 
     /**
      * Should be invoked after the property structure of this widget has been updated and the

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -466,8 +466,13 @@ declare abstract class TWWidget {
      * @param defaultValue      An optional default value that will be returned if the property has not yet been assigned any value.
      * @return                  The property's value.
      */
-    getProperty(property: string, defaultValue?: any): any;
-
+    getProperty: {
+        // When specifying a default value, infer the type from that value
+        <T = any>(name: string, defaultValue?: T): T;
+        (name: 'Type'): string;
+        (name: 'DisplayName'): string;
+        (name: 'Id'): string;
+    };
     /**
      * Sets the value of the given property.
      * If this property is bound to any targets, they will be updated accordingly.
@@ -1041,7 +1046,13 @@ declare abstract class TWRuntimeWidget extends TWWidget {
      * @param defaultValue      Defaults to `undefined`. An optional default value to return if this property doesn't yet have a value.
      * @return                  The property's value, or the value specified in the `defaultValue` parameter if the property hasn't yet been set.
      */
-    getProperty(name: string, defaultValue?: any | undefined): any | undefined;
+    getProperty: {
+        // When specifying a default value, infer the type from that value
+        <T = any>(name: string, defaultValue?: T): T;
+        (name: 'Type'): string;
+        (name: 'DisplayName'): string;
+        (name: 'Id'): string;
+    };
 
     /**
      * Sets the value of the given property.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2077,3 +2077,40 @@ declare interface TWNamespace {
 }
 
 declare const TW: TWNamespace;
+
+interface ThingworxInvokerCtorParams {
+  entityType: string;
+  entityName: string;
+  characteristic: string;
+  target: string;
+  apiMethod: "get" | "delete" | "post" | "put";
+  parameters?: Record<string, unknown>;
+  properties?: Record<string, unknown>;
+}
+
+/**
+ * The `ThingworxInvoker` is available globally and allows
+ * for calling ThingWorx endpoints in a reliable way, while 
+ * being able to transform the results (for example, uncompressing infotables)
+ */
+declare class ThingworxInvoker {
+  /**
+   * Parameters the service will be called with
+   */
+  parameters: Record<string, unknown>;
+  
+  /**
+   * Create a new ThingworxInvoker class for a given thingworx endpoint
+   */
+  constructor(args: ThingworxInvokerCtorParams);
+
+  /**
+   * Invoke the specified service of this invoker
+   * @param resolve Method to be called if the service is successfully invoked
+   * @param reject Method to be called if the service failed
+   */
+  invokeService(
+    resolve: (data: { result: TWInfotable }) => void,
+    reject: (details: unknown) => void
+  );
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1995,6 +1995,7 @@ declare interface TWNamespace {
         [prop: string]: any;
         Widget: typeof TWComposerWidget;
         Widgets: Dictionary<typeof TW.IDE.Widget>;
+        convertLocalizableString: (token: string) => string;
     };
     Runtime: {
         [prop: string]: any;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2114,3 +2114,104 @@ declare class ThingworxInvoker {
     reject: (details: unknown) => void
   );
 }
+
+declare type TWLocation = {
+  latitude: number;
+  longitude: number;
+  altitude?: number;
+  units?: string;
+};
+
+declare interface TWQuery<T = any> {
+  sorts?: SortFilter<T, keyof T>[];
+  filters: QueryFilter<T>;
+}
+
+declare interface SortFilter<T, K extends keyof T> {
+  fieldName: K;
+  isAscending?: boolean;
+  isCaseSensitive?: boolean;
+}
+
+declare interface AndOrQueryFilter<T> {
+  type: "AND" | "OR";
+  filters: QueryFilter<T>[];
+}
+
+type SingleValueFilter<T> = keyof T extends infer K
+  ? K extends keyof T
+    ? {
+        type: "EQ" | "NE" | "LIKE" | "GT" | "LT" | "LE" | "GE" | "NOTLIKE";
+        fieldName: K;
+        value: T[K];
+      }
+    : never
+  : never;
+
+type RegexFilter<T> = keyof T extends infer K
+  ? K extends keyof T
+    ? T[K] extends string
+      ? {
+          type: "Matches" | "NotMatches";
+          fieldName: K;
+          expression: string;
+        }
+      : never
+    : never
+  : never;
+
+type BetweenFilter<T> = keyof T extends infer K
+  ? K extends keyof T
+    ? {
+        type: "BETWEEN" | "NOTBETWEEN" | "Between" | "NotBetween";
+        fieldName: K;
+        from: T[K];
+        to: T[K];
+      }
+    : never
+  : never;
+
+type TaggedFilter<T> = {
+  type: "TAGGED" | "NOTTAGGED";
+  fieldName: string;
+  tags: { vocabulary: string; vocabularyTerm: string }[] | string;
+};
+
+type ContainsFilter<T> = keyof T extends infer K
+  ? K extends keyof T
+    ? {
+        type: "IN" | "NOTIN";
+        fieldName: K;
+        values: T[K][];
+      }
+    : never
+  : never;
+
+type MissingValueFilter<T> = {
+  type: "MissingValue" | "NotMissingValue";
+  fieldName: keyof T;
+};
+
+type LocationFilter<T> = keyof T extends infer K
+  ? K extends keyof T
+    ? T[K] extends TWLocation
+      ? {
+          type: "Near" | "NotNear";
+          fieldName: K;
+          distance: number;
+          units: "M" | "K" | "N";
+          location: T[K];
+        }
+      : never
+    : never
+  : never;
+
+type QueryFilter<T> =
+  | AndOrQueryFilter<T>
+  | SingleValueFilter<T>
+  | BetweenFilter<T>
+  | RegexFilter<T>
+  | TaggedFilter<T>
+  | ContainsFilter<T>
+  | MissingValueFilter<T>
+  | LocationFilter<T>;

--- a/widgetIDESupport/index.js
+++ b/widgetIDESupport/index.js
@@ -543,12 +543,12 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                     },
 
                     afterSetProperty(key, value) {
-                        if (this[didSetSymbol] && (key in this[didSetSymbol])) {
-                            return this[this[didSetSymbol][key]](value);
-                        }
                         // call the setters that are associated with this property
                         if (this._decoratedProperties[key]) {
                             this[key] = value;
+                        }
+                        if (this[didSetSymbol] && (key in this[didSetSymbol])) {
+                            return this[this[didSetSymbol][key]](value);
                         }
                     },
 

--- a/widgetIDESupport/index.js
+++ b/widgetIDESupport/index.js
@@ -186,7 +186,7 @@ function getSymbol(symbolDesc) {
 /**
  * The version of the TWComposerWidget prototype.
  */
-const prototypeVersion = 4;
+const prototypeVersion = 5;
 
 const willSetSymbol = getSymbol('@@_willSet');
 const didSetSymbol = getSymbol('@@_didSet');
@@ -545,6 +545,10 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                     afterSetProperty(key, value) {
                         if (this[didSetSymbol] && (key in this[didSetSymbol])) {
                             return this[this[didSetSymbol][key]](value);
+                        }
+                        // call the setters that are associated with this property
+                        if (this._decoratedProperties[key]) {
+                            this[key] = value;
                         }
                     },
 


### PR DESCRIPTION
## Intent

- some light improvements of the library, most of it is improved typescript types

## Implementation

- Feature changes
  - At ide, when declaring a `@property`, using a setter will cause that setter to be called after the value of the property is changed in the composer. Note that the `didSet(functionName)` decorator can still be used, but setters allow for the value to be declared in the same place
- Documentation improvements
  - Make `TWInfotable<T>` generic.
  - Improved `ideWidget.updateProperties()` with all known params
  - Added typescript types for `ThingworxInvoker`
  - Added documentation for `TWQuery`
  - Make `getProperty()` calls generic
