### PR TITLE
Remove setter invocation in afterSetProperty

### DIFF
--- a/widgetIDESupport/index.js
+++ b/widgetIDESupport/index.js
@@ -637,10 +637,6 @@ if (TW.IDE && (typeof TW.IDE.Widget == 'function')) {
                     },
 
                     afterSetProperty(key, value) {
-                        // call the setters that are associated with this property
-                        if (this._decoratedProperties[key]) {
-                            this[key] = value;
-                        }
                         if (this[didSetSymbol] && (key in this[didSetSymbol])) {
                             return this[this[didSetSymbol][key]](value);
                         }


### PR DESCRIPTION
Removes the automatic setter invocation from `afterSetProperty`, since starting with TW 9.5 this gets called with the translated value of tokens and prevents localization from working with these properties.